### PR TITLE
Update CI for Visual Studio 2026

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -9,8 +9,6 @@ on:
       - "**.md"
       - "docs/**"
   push:
-    branches:
-      - main
     paths-ignore:
       - .github/**
       - "!.github/workflows/linux_build.yml"

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -9,8 +9,6 @@ on:
       - "**.md"
       - "docs/**"
   push:
-    branches:
-      - main
     paths-ignore:
       - .github/**
       - "!.github/workflows/macos_build.yml"

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -42,6 +42,8 @@ jobs:
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v3
+      with:
+        vs-version: '[18.0,19.0)'
 
     - name: Setup Deno
       uses: denoland/setup-deno@v2
@@ -51,7 +53,7 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.28.x'
+        cmake-version: '4.2.x'
 
     - name: Build zlib
       run: |
@@ -61,8 +63,8 @@ jobs:
         move zlib-1.3.2 zlib
         del zlib.zip
         cd zlib
-        cmake -G "Visual Studio 17 2022" -A x64 -S . -B contrib/vstudio/vc17
-        cmake --build contrib/vstudio/vc17 --config Release
+        cmake -G "Visual Studio 18 2026" -A x64 -S . -B contrib/vstudio/vc18
+        cmake --build contrib/vstudio/vc18 --config Release
 
     - name: Download ZenLib
       run: |
@@ -75,8 +77,8 @@ jobs:
         git clone -b ${{ env.MEDIA_INFO_LIB_VERSION }} --depth 1 https://github.com/MediaArea/MediaInfoLib.git
         cd BetterMediaInfo/scripts/ts
         deno task patch
-        cd ../../../MediaInfoLib\Project\MSVC2022
-        msbuild MediaInfoLib.sln -t:rebuild -verbosity:diag -property:Configuration=Release -property:Platform=x64
+        cd ../../../MediaInfoLib\Project\MSVC2026
+        msbuild MediaInfoLib.slnx -t:rebuild -verbosity:diag -property:Configuration=Release -property:Platform=x64
 
     - name: Copy DLLs
       run: |

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -9,8 +9,6 @@ on:
       - "**.md"
       - "docs/**"
   push:
-    branches:
-      - main
     paths-ignore:
       - .github/**
       - "!.github/workflows/windows_build.yml"

--- a/docs/development.md
+++ b/docs/development.md
@@ -113,8 +113,8 @@ del zlib.zip
 
 ```sh
 cd zlib
-cmake -G "Visual Studio 17 2022" -A x64 -S . -B contrib/vstudio/vc17
-cmake --build contrib/vstudio/vc17 --config Release
+cmake -G "Visual Studio 18 2026" -A x64 -S . -B contrib/vstudio/vc18
+cmake --build contrib/vstudio/vc18 --config Release
 ```
 
 * Patch MediaInfoLib to work with cmake-built zlib.
@@ -124,11 +124,11 @@ cd scripts/ts
 deno task patch
 ```
 
-* Build MediaInfoLib in Visual Studio 2022.
+* Build MediaInfoLib in Visual Studio 2026.
 
 ```sh
-cd MediaInfoLib\Project\MSVC2022
-msbuild MediaInfoLib.sln -t:rebuild -verbosity:diag -property:Configuration=Release -property:Platform=x64
+cd MediaInfoLib\Project\MSVC2026
+msbuild MediaInfoLib.slnx -t:rebuild -verbosity:diag -property:Configuration=Release -property:Platform=x64
 ```
 
 ## Generate bindings.rs on Windows
@@ -145,7 +145,7 @@ cargo install bindgen-cli
 
 ```sh
 cd BetterMediaInfo
-set LIBCLANG_PATH=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin\libclang.dll
+set LIBCLANG_PATH=C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Tools\Llvm\x64\bin\libclang.dll
 bindgen ^
   --allowlist-item "MediaInfo\w+" ^
   -o src-tauri\src\bindings.rs ^

--- a/scripts/ts/patch-mediainfolib.ts
+++ b/scripts/ts/patch-mediainfolib.ts
@@ -20,10 +20,13 @@ import * as path from "https://deno.land/std/path/mod.ts";
 
 const rootDirPath = path.join(
   path.dirname(path.fromFileUrl(import.meta.url)),
-  "../../../"
+  "../../../",
 );
 
-function patchFile(filePath: string, replacements: Array<[string | RegExp, string]>) {
+function patchFile(
+  filePath: string,
+  replacements: Array<[string | RegExp, string]>,
+) {
   const fullPath = path.join(rootDirPath, filePath);
   if (!fs.existsSync(fullPath)) {
     console.error(`%c${fullPath} is not found.`, "color: red");
@@ -48,9 +51,16 @@ function patchFile(filePath: string, replacements: Array<[string | RegExp, strin
   }
 }
 
-function patchAllVcxproj(dirPath: string, replacements: Array<[string | RegExp, string]>) {
+function patchAllVcxproj(
+  dirPath: string,
+  replacements: Array<[string | RegExp, string]>,
+) {
   const fullDirPath = path.join(rootDirPath, dirPath);
-  for (const entry of fs.walkSync(fullDirPath, { exts: [".vcxproj", ".sln"] })) {
+  for (
+    const entry of fs.walkSync(fullDirPath, {
+      exts: [".vcxproj", ".sln", ".slnx"],
+    })
+  ) {
     if (entry.isFile) {
       const relativePath = path.relative(rootDirPath, entry.path);
       patchFile(relativePath, replacements);
@@ -59,26 +69,32 @@ function patchAllVcxproj(dirPath: string, replacements: Array<[string | RegExp, 
 }
 
 // Create symlink: zlibstatic.vcxproj -> zlibstat.vcxproj
-const symlinkTarget = path.join(rootDirPath, "zlib/contrib/vstudio/vc17/zlibstat.vcxproj");
+const symlinkTarget = path.join(
+  rootDirPath,
+  "zlib/contrib/vstudio/vc18/zlibstat.vcxproj",
+);
 if (!fs.existsSync(symlinkTarget)) {
   Deno.symlinkSync("zlibstatic.vcxproj", symlinkTarget, { type: "file" });
   console.info(`Created symlink ${symlinkTarget}`);
 }
 
-// Patch ReleaseWithoutAsm -> Release in all sln and vcxproj files
-patchAllVcxproj("MediaInfoLib/Project/MSVC2022", [
+// Patch ReleaseWithoutAsm -> Release in all solution and vcxproj files
+patchAllVcxproj("MediaInfoLib/Project/MSVC2026", [
   ["ReleaseWithoutAsm", "Release"],
 ]);
 
 // Patch _CRT_SECURE_NO_WARNINGS into all vcxproj PreprocessorDefinitions
-patchAllVcxproj("MediaInfoLib/Project/MSVC2022", [
-  ["%(PreprocessorDefinitions)", "_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)"],
+patchAllVcxproj("MediaInfoLib/Project/MSVC2026", [
+  [
+    "%(PreprocessorDefinitions)",
+    "_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)",
+  ],
 ]);
 
 // Patch zlib dependency into MediaInfoDll.vcxproj
-patchFile("MediaInfoLib/Project/MSVC2022/Dll/MediaInfoDll.vcxproj", [
+patchFile("MediaInfoLib/Project/MSVC2026/Dll/MediaInfoDll.vcxproj", [
   [
     "%(AdditionalDependencies)</AdditionalDependencies>",
-    "..\\..\\..\\..\\zlib\\contrib\\vstudio\\vc17\\Release\\zs.lib;%(AdditionalDependencies)</AdditionalDependencies>",
+    "..\\..\\..\\..\\zlib\\contrib\\vstudio\\vc18\\Release\\zs.lib;%(AdditionalDependencies)</AdditionalDependencies>",
   ],
 ]);

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -119,7 +119,7 @@ fn main() {
       is_static: false,
       file_name: "MediaInfo.dll".to_owned(),
       lib_name: "MediaInfo".to_owned(),
-      source_path: "MediaInfoLib\\Project\\MSVC2022\\x64\\Release".to_owned(),
+      source_path: "MediaInfoLib\\Project\\MSVC2026\\x64\\Release".to_owned(),
     }
   } else {
     ExternalLib {

--- a/src-tauri/scripts/copy_dlls.cjs
+++ b/src-tauri/scripts/copy_dlls.cjs
@@ -14,7 +14,7 @@ try {
   copy(
     path.join(
       repoRoot,
-      "..\\MediaInfoLib\\Project\\MSVC2022\\x64\\Release\\MediaInfo.dll"
+      "..\\MediaInfoLib\\Project\\MSVC2026\\x64\\Release\\MediaInfo.dll"
     ),
     path.join(repoRoot, "src-tauri\\MediaInfo.dll")
   );


### PR DESCRIPTION
﻿## Summary
- update the Windows build to use the Visual Studio 2026 toolchain, CMake generator, zlib project path, and MediaInfoLib MSVC2026 solution
- update local Windows build helpers and development docs to use MediaInfoLib MSVC2026 outputs
- allow CI workflows to run on branch pushes instead of only pushes to main

## Why
GitHub Actions is migrating the Windows images behind `windows-latest` to Visual Studio 2026. The Windows workflow was already landing on a VS2026 image, but zlib and MediaInfoLib still used VS2022 project paths and generator settings. Branch pushes also could not run CI because the workflows pinned push events to `main`.

## Validation
- Windows CI was re-run successfully on the branch after the workflow trigger restriction was removed
- `rg` confirmed stale VS2022 workflow/build references were removed
- `deno fmt --check scripts\ts\patch-mediainfolib.ts`
- `git diff --check`